### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ SRCDIR := $(BUILDDIR)/src
 LIBDIR := $(BUILDDIR)/lib
 BINDIR := $(BUILDDIR)/bin
 
+default: $(LIBDIR)/libfftw%
+
+# Define directory-creation rule for many directories we'll need
+define dir_rule
+$(1):
+	@mkdir -p $(1)
+endef
+$(foreach d,$(SRCDIR) $(LIBDIR) $(BINDIR),$(eval $(call dir_rule,$(d))))
+
 TAR := $(shell which gtar 2>/dev/null || which tar 2>/dev/null)
 
 FFTW_VERS := $(shell cat VERSION)
@@ -24,16 +33,14 @@ endif
 FFTW_CONFIG += --enable-single
 
 .PHONY: default
-default: $(LIBDIR)/libfftw%
 
-$(SRCDIR)/fftw-$(FFTW_VERS).tar.gz:
-	-mkdir -p $(BUILDDIR) $(SRCDIR) $(LIBDIR) $(BINDIR)
+$(SRCDIR)/fftw-$(FFTW_VERS).tar.gz: | $(SRCDIR)
 	curl -fkL --connect-timeout 15 -y 15 http://www.fftw.org/$(notdir $@) -o $@
 
 $(SRCDIR)/configure: $(SRCDIR)/fftw-$(FFTW_VERS).tar.gz
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
 
-$(LIBDIR)/libfftw%: $(SRCDIR)/configure
+$(LIBDIR)/libfftw%: $(SRCDIR)/configure | $(LIBDIR) $(BINDIR)
 	# Try to configure with AVX support, if that fails then try again without
 	(cd $(dir $<) && \
 	    ./configure $(CONFIG) $(FFTW_CONFIG) --enable-avx || \


### PR DESCRIPTION
This built successfully for me with the following `docker` invocation:

```
docker run --user=$(id -u):$(id -g) -ti -v $(pwd):/src -w /src staticfloat/julia_workerbase:centos6_9-x64 make
```

Options explanation:

* `--user`: Set the UID/GID of the building user within the `Docker` container to match the file permissions on your host.
* `-ti`: Allocate a psudo-TTY and hook up stdin.
* `-v`: Mount `$(pwd)` volume at `/src` within the container.
* `-w` : Set the working directory
* `staticfloat/julia_workerbase:centos6_9-x64`: Set the run environment (docker image) to the `x64` CentOS 6.9 image.  Change `x64` to `x86` to build 32-bit binaries.
* `make`: Run this command within the container.